### PR TITLE
Update plugin parent POM

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin(useAci: true)
+buildPlugin(useAci: true,
+            configurations: [
+                [platform: 'linux', jdk: '11']
+            ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>5.13.0</version>
+    <version>5.24.0</version>
     <relativePath />
   </parent>
 
@@ -15,11 +15,12 @@
   <version>${revision}${changelist}</version>
 
   <description>Provides Popper.js for Jenkins plugins.</description>
-  <url>https://github.com/jenkinsci/popper-api-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <properties>
     <revision>1.16.1-3</revision>
     <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <popper.version>1.16.1-lts</popper.version>
 
     <module.name>${project.groupId}.popper</module.name>
@@ -96,9 +97,9 @@
   </build>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/popper-api-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/popper-api-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/popper-api-plugin</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Provides Popper.js for Jenkins plugins.
+</div>


### PR DESCRIPTION
I have been attempting to run PCT tests in `jenkinsci/bom` against Java 17 and newer versions of PCT, and this plugin is running into failures because its parent POM is too old. This PR updates the parent POM to the latest build toolchain from jenkinsci/analysis-pom-plugin#446 to facilitate Java 17 compatibility testing and PCT updates in `jenkinsci/bom`.